### PR TITLE
メンヘラを破壊

### DIFF
--- a/src/content/links/linksData.json
+++ b/src/content/links/linksData.json
@@ -4,7 +4,7 @@
         "siteName": "Laddgeのページ",
         "twitterUrl": "laddge_",
         "name": "Laddge",
-        "description": "技術力つよつよなメンヘラ24生"
+        "description": "技術力つよつよな24生"
     },
     {
         "siteUrl": "https://kqiita.github.io/",


### PR DESCRIPTION
メンヘラという言葉は強めの悪口なのではという意見が出たので、破壊することにした。